### PR TITLE
Add dotenv config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-This is simply a backend of python classes in order to deploy me project simulations.
+This repository contains a collection of notebooks and helper modules used in my simulation projects.
+
+## Configuration
+
+Environment variables are used to access external services. You can either set them in your shell or create a `.env` file in the project root. The following variables may be required depending on which notebooks you run:
+
+- `OPENAI_API_KEY` &ndash; API token for the OpenAI client
+- `NEO4J_URI` &ndash; connection URI for your Neo4j instance
+- `NEO4J_USERNAME` &ndash; Neo4j username
+- `NEO4J_LOCALPWD` &ndash; password for the above user
+- `ASTRA_ENDPOINT` &ndash; endpoint URL for Astra DB
+- `ASTRA_TOKEN` &ndash; API token for Astra DB (optional if using other auth)
+
+Create a `.env` file with lines of the form `VAR=value` or export these variables before running the notebooks.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from dotenv import load_dotenv
+import os
+
+# Load environment variables from a .env file if it exists
+_env_path = Path(__file__).resolve().parent / '.env'
+load_dotenv(dotenv_path=_env_path, override=False)
+
+def get_env(name: str, default=None, required: bool = False):
+    """Retrieve environment variable from os.environ.
+
+    Args:
+        name: The environment variable name.
+        default: Optional default if the variable is not set.
+        required: If True, raise an error when the variable is missing.
+
+    Returns:
+        The value of the environment variable or the default.
+    """
+    value = os.getenv(name, default)
+    if required and value is None:
+        raise EnvironmentError(f"Environment variable '{name}' is required")
+    return value


### PR DESCRIPTION
## Summary
- add a simple `config` module that reads environment variables
- mention required environment variables in the README

## Testing
- `python -m py_compile config.py`


------
https://chatgpt.com/codex/tasks/task_e_6868dd9674b483259d710398a18590e9