### PR TITLE
Implement simulation endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 
-from .routes import openai_bp, astra_bp
+from .routes import openai_bp, astra_bp, sim_bp
 
 
 def create_app() -> Flask:
@@ -8,6 +8,7 @@ def create_app() -> Flask:
     app = Flask(__name__)
     app.register_blueprint(openai_bp)
     app.register_blueprint(astra_bp)
+    app.register_blueprint(sim_bp)
     return app
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,9 +2,11 @@ from flask import Blueprint, jsonify, request
 
 from .openai_utils import summarize
 from .astra_utils import update_record
+from .simulation_utils import run_simulation
 
 openai_bp = Blueprint('openai', __name__, url_prefix='/openai')
 astra_bp = Blueprint('astra', __name__, url_prefix='/astra')
+sim_bp = Blueprint('sim', __name__, url_prefix='/simulate')
 
 
 @openai_bp.route('/summarize', methods=['POST'])
@@ -19,5 +21,15 @@ def openai_summarize():
 def astra_update():
     data = request.get_json(silent=True) or {}
     result = update_record(data)
+    return jsonify(result)
+
+
+@sim_bp.route('', methods=['POST'])
+def simulate_run():
+    """Run a portfolio simulation and return the results."""
+    data = request.get_json(silent=True) or {}
+    events = data.get('events') or data.get('yaml')
+    steps = data.get('steps', 12)
+    result = run_simulation(events, steps=steps)
     return jsonify(result)
 

--- a/app/simulation_utils.py
+++ b/app/simulation_utils.py
@@ -1,0 +1,47 @@
+"""Utility functions for running portfolio simulations."""
+
+from __future__ import annotations
+
+from typing import Any
+import simpy
+import pandas as pd
+
+from sim import Portfolio, parseYAML
+
+
+def run_simulation(events: Any | None = None, *, steps: int = 12) -> dict:
+    """Run a simple portfolio simulation.
+
+    Parameters
+    ----------
+    events : str | list[dict] | None
+        Either a YAML string or a list of event dictionaries describing the
+        projects to create.
+    steps : int, optional
+        Number of simulation steps to run, by default 12.
+
+    Returns
+    -------
+    dict
+        Simulation results containing projects, transactions and budget records.
+    """
+    if isinstance(events, str):
+        try:
+            events = parseYAML(events)
+        except Exception:
+            events = []
+    events = events or []
+
+    env = simpy.Environment()
+    portfolio = Portfolio(env)
+
+    if events:
+        portfolio.set_portfolio(events)
+
+    portfolio.run(until=steps)
+
+    return {
+        "projects": portfolio.list_projects().to_dict(orient="records"),
+        "transactions": portfolio.list_transactions().to_dict(orient="records"),
+        "budget": portfolio.getbudget().to_dict(orient="records"),
+    }


### PR DESCRIPTION
## Summary
- register new `/simulate` blueprint in the Flask app
- provide utility for running portfolio simulations
- expose `/simulate` POST endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e98ec91c8325ba4bb52c930488a6