### PR TITLE
Enable YAML editing in web UI

### DIFF
--- a/templates/partials/form.html
+++ b/templates/partials/form.html
@@ -15,6 +15,11 @@
               </div>
               </div>
             </div>
+            <div class="mt-4">
+              <label for="yaml_file_editor" class="block mb-2 font-semibold text-slate-600">Edit YAML Content</label>
+              <textarea id="yaml_file_editor" data-target="yaml_file" rows="10" class="yaml-editor w-full p-3 border border-gray-300 rounded-md font-mono text-sm" placeholder="Edit simulation YAML here..."></textarea>
+              <button type="button" class="download-file mt-2 text-indigo-500 underline" data-target="yaml_file">Download YAML</button>
+            </div>
           </div>
 
           <!-- Optional Data Files -->
@@ -36,6 +41,11 @@
               </div>
               </div>
             </div>
+            <div class="mt-4">
+              <label for="fcrdata_file_editor" class="block mb-2 font-semibold text-slate-600">Edit FCR Data</label>
+              <textarea id="fcrdata_file_editor" data-target="fcrdata_file" rows="8" class="yaml-editor w-full p-3 border border-gray-300 rounded-md font-mono text-sm" placeholder="Edit FCR data YAML..."></textarea>
+              <button type="button" class="download-file mt-2 text-indigo-500 underline" data-target="fcrdata_file">Download YAML</button>
+            </div>
 
             <div class="mb-5">
               <label for="supportdata_file" class="block mb-2 font-semibold text-slate-600">Support Data YAML File</label>
@@ -49,6 +59,11 @@
                 <button type="button" class="clear-file ml-2 text-red-500 hover:text-red-700" data-target="supportdata_file">✕ Clear</button>
               </div>
               </div>
+            </div>
+            <div class="mt-4">
+              <label for="supportdata_file_editor" class="block mb-2 font-semibold text-slate-600">Edit Support Data</label>
+              <textarea id="supportdata_file_editor" data-target="supportdata_file" rows="8" class="yaml-editor w-full p-3 border border-gray-300 rounded-md font-mono text-sm" placeholder="Edit support data YAML..."></textarea>
+              <button type="button" class="download-file mt-2 text-indigo-500 underline" data-target="supportdata_file">Download YAML</button>
             </div>
           </div>
 

--- a/templates/partials/index_scripts.html
+++ b/templates/partials/index_scripts.html
@@ -46,6 +46,10 @@
                   localStorage.removeItem('file_' + targetId);
                   info.classList.add('hidden');
                   area.classList.remove('border-indigo-500', 'bg-indigo-50');
+                  const editor = document.getElementById(targetId + '_editor');
+                  if (editor) {
+                      editor.value = '';
+                  }
               });
           });
 
@@ -60,11 +64,12 @@
                           console.log(`Found stored file: ${id}, ${data.name}, ${data.content ? data.content.length + ' bytes' : 'missing content'}`);
                           const area = document.querySelector(`.file-upload-area[data-target="${id}"]`);
                           const info = document.getElementById(id + '_info');
-                          
+                          const editor = document.getElementById(id + '_editor');
+
                           if (info) {
                               info.innerHTML = `Selected: ${data.name} (${(data.size/1024).toFixed(1)} KB) <button type="button" class="clear-file ml-2 text-red-500 hover:text-red-700" data-target="${id}">✕ Clear</button>`;
                               info.classList.remove('hidden');
-                              
+
                               // Add event listener to the clear button
                               const clearBtn = info.querySelector('.clear-file');
                               if (clearBtn) {
@@ -76,10 +81,17 @@
                                       if (area) {
                                           area.classList.remove('border-indigo-500', 'bg-indigo-50');
                                       }
+                                      if (editor) {
+                                          editor.value = '';
+                                      }
                                   });
                               }
                           }
-                          
+
+                          if (editor) {
+                              editor.value = data.content || '';
+                          }
+
                           if (area) {
                               area.classList.add('border-indigo-500', 'bg-indigo-50');
                           }
@@ -87,6 +99,36 @@
                   } catch (error) {
                       console.error(`Error loading ${id} from localStorage:`, error);
                   }
+              });
+
+              // Set up editor listeners
+              document.querySelectorAll('.yaml-editor').forEach(textarea => {
+                  textarea.addEventListener('input', () => {
+                      const targetId = textarea.getAttribute('data-target');
+                      let stored = localStorage.getItem('file_' + targetId);
+                      stored = stored ? JSON.parse(stored) : { name: targetId + '.yaml', type: 'text/yaml' };
+                      stored.content = textarea.value;
+                      stored.size = textarea.value.length;
+                      localStorage.setItem('file_' + targetId, JSON.stringify(stored));
+                  });
+              });
+
+              // Download buttons
+              document.querySelectorAll('.download-file').forEach(btn => {
+                  btn.addEventListener('click', () => {
+                      const id = btn.getAttribute('data-target');
+                      const storedStr = localStorage.getItem('file_' + id);
+                      if (storedStr) {
+                          const f = JSON.parse(storedStr);
+                          const blob = new Blob([f.content || ''], { type: 'text/yaml' });
+                          const url = URL.createObjectURL(blob);
+                          const a = document.createElement('a');
+                          a.href = url;
+                          a.download = f.name || id + '.yaml';
+                          a.click();
+                          URL.revokeObjectURL(url);
+                      }
+                  });
               });
           });
 
@@ -119,6 +161,10 @@
                           const content = event.target.result;
                           const payload = { name: file.name, size: file.size, type: file.type, content };
                           localStorage.setItem('file_' + input.id, JSON.stringify(payload));
+                          const editor = document.getElementById(input.id + '_editor');
+                          if (editor) {
+                              editor.value = content;
+                          }
                           console.log(`File ${file.name} saved to localStorage for ${input.id} (${content.length} bytes)`);
                       } catch (error) {
                           console.error(`Error saving file ${file.name} to localStorage:`, error);


### PR DESCRIPTION
## Summary
- add textareas to edit YAML files in memory and download them
- sync editors with localStorage and update upload logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6869489191a48325b619e88cbcc4c63b